### PR TITLE
IRDL-to-C++: support cross-compilation

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -207,6 +207,7 @@ include_directories(BEFORE
 # Adding tools/mlir-tblgen here as calling add_tablegen sets some variables like
 # MLIR_TABLEGEN_EXE in PARENT_SCOPE which gets lost if that folder is included
 # from another directory like tools
+add_subdirectory(tools/mlir-irdl-to-cpp)
 add_subdirectory(tools/mlir-linalg-ods-gen)
 add_subdirectory(tools/mlir-pdll)
 add_subdirectory(tools/mlir-tblgen)

--- a/mlir/cmake/modules/IRDLToCpp.cmake
+++ b/mlir/cmake/modules/IRDLToCpp.cmake
@@ -1,8 +1,8 @@
 function(add_irdl_to_cpp_target target irdl_file)
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${irdl_file}.cpp.inc
-    COMMAND $<TARGET_FILE:mlir-irdl-to-cpp> ${CMAKE_CURRENT_SOURCE_DIR}/${irdl_file} -o ${CMAKE_CURRENT_BINARY_DIR}/${irdl_file}.cpp.inc
-    DEPENDS mlir-irdl-to-cpp ${irdl_file}
+    COMMAND ${MLIR_IRDL_TO_CPP_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/${irdl_file} -o ${CMAKE_CURRENT_BINARY_DIR}/${irdl_file}.cpp.inc
+    DEPENDS ${MLIR_IRDL_TO_CPP_TARGET} ${irdl_file}
     COMMENT "Building ${irdl_file}..."
   )
   add_custom_target(${target} ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${irdl_file}.cpp.inc)

--- a/mlir/tools/CMakeLists.txt
+++ b/mlir/tools/CMakeLists.txt
@@ -1,4 +1,3 @@
-add_subdirectory(mlir-irdl-to-cpp)
 add_subdirectory(mlir-lsp-server)
 add_subdirectory(mlir-opt)
 add_subdirectory(mlir-parser-fuzzer)

--- a/mlir/tools/mlir-irdl-to-cpp/CMakeLists.txt
+++ b/mlir/tools/mlir-irdl-to-cpp/CMakeLists.txt
@@ -1,7 +1,28 @@
-add_mlir_tool(mlir-irdl-to-cpp
+add_llvm_executable(mlir-irdl-to-cpp
     mlir-irdl-to-cpp.cpp
   )
 mlir_target_link_libraries(mlir-irdl-to-cpp
   PRIVATE
   MLIRTargetIRDLToCpp
   )
+
+# Set up a native build when cross-compiling.
+if(LLVM_USE_HOST_TOOLS)
+  build_native_tool(
+    mlir-irdl-to-cpp
+    MLIR_IRDL_TO_CPP_EXE
+
+    # Native tool must depend on target tool so that the native tool gets
+    # properly rebuilt when the target tool changes.
+    DEPENDS mlir-irdl-to-cpp
+  )
+  add_custom_target(mlir-irdl-to-cpp-host DEPENDS ${MLIR_IRDL_TO_CPP_EXE})
+  set(MLIR_IRDL_TO_CPP_TARGET mlir-irdl-to-cpp-host)
+else()
+  set(MLIR_IRDL_TO_CPP_EXE $<TARGET_FILE:mlir-irdl-to-cpp>)
+  set(MLIR_IRDL_TO_CPP_TARGET mlir-irdl-to-cpp)
+endif()
+
+# Save the executable path and target name to the cache to expose it globally.
+set(MLIR_IRDL_TO_CPP_EXE "${MLIR_IRDL_TO_CPP_EXE}" CACHE INTERNAL "")
+set(MLIR_IRDL_TO_CPP_TARGET "${MLIR_IRDL_TO_CPP_TARGET}" CACHE INTERNAL "")


### PR DESCRIPTION
I had forgotten that the mlir-irdl-to-cpp tool should also compile for host.
I have not yet been able to test it in a cross-compile scenario because I struggle to understand how to do that :)
But here is the PR for now.