### PR TITLE
irdl-to-cpp: Add testbench

### DIFF
--- a/mlir/lib/Target/IRDLToCpp/CMakeLists.txt
+++ b/mlir/lib/Target/IRDLToCpp/CMakeLists.txt
@@ -2,6 +2,17 @@ add_mlir_translation_library(MLIRTargetIRDLToCpp
   TranslationRegistration.cpp
   IRDLToCpp.cpp
 
+  Templates/DialectDecl.txt
+  Templates/DialectDef.txt
+  Templates/Header.txt
+  Templates/OperationDef.txt
+  Templates/PerOperationDecl.txt
+  Templates/PerOperationDef.txt
+  Templates/TypeDecl.txt
+  Templates/TypeDef.txt
+  Templates/TypeHeaderDecl.txt
+  Templates/TypeHeaderDef.txt
+
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRIRDL

--- a/mlir/lib/Target/IRDLToCpp/Templates/DialectDef.txt
+++ b/mlir/lib/Target/IRDLToCpp/Templates/DialectDef.txt
@@ -10,7 +10,6 @@
 */
 
 R"(
-MLIR_DEFINE_EXPLICIT_TYPE_ID({3}::{2})
 {0}
 {2}::{2}(::mlir::MLIRContext *context)
     : ::mlir::Dialect(getDialectNamespace(), context, ::mlir::TypeID::get<{2}>())
@@ -30,4 +29,5 @@ void {2}::initialize() {{
     >();
 }
 {1}
+MLIR_DEFINE_EXPLICIT_TYPE_ID({3}::{2})
 )"

--- a/mlir/test/lib/Dialect/TestIRDLToCpp/TestIRDLToCppDialect.h
+++ b/mlir/test/lib/Dialect/TestIRDLToCpp/TestIRDLToCppDialect.h
@@ -6,15 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file includes TestIRDLToCpp dialect.
+// This file includes TestIRDLToCpp dialect headers.
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/IR/Dialect.h"
-#include "mlir/IR/Region.h"
+#ifndef MLIR_TEST_LIB_DIALECT_TESTIRDLTOCPP_TESTIRDLTOCPPDIALECT_H
+#define MLIR_TEST_LIB_DIALECT_TESTIRDLTOCPP_TESTIRDLTOCPPDIALECT_H
 
-#include "TestIRDLToCppDialect.h"
-
-#define GEN_DIALECT_DEF
+#define GEN_DIALECT_DECL_HEADER
 #include "test_irdl_to_cpp.irdl.mlir.cpp.inc"
 
+#endif // MLIR_TEST_LIB_DIALECT_TESTIRDLTOCPP_TESTIRDLTOCPPDIALECT_H


### PR DESCRIPTION
This is a testbench for IRDL to C++. It does not compile for now because the tool has a couple bugs, but this helps spot them. This also fixes CMake to spot changes to templates.